### PR TITLE
Create mapper between domain and remote models

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/NoteRemote.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/NoteRemote.java
@@ -3,7 +3,7 @@ package br.org.cesar.discordtime.stickysessions.data.remote.model;
 import com.google.gson.annotations.Expose;
 import com.google.gson.annotations.SerializedName;
 
-public class Note {
+public class NoteRemote {
 
     @SerializedName("description")
     @Expose
@@ -18,6 +18,6 @@ public class Note {
     @Expose
     public String sessionId;
 
-    public Note(){}
+    public NoteRemote(){}
 
 }

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/SessionRemote.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/SessionRemote.java
@@ -6,7 +6,7 @@ import com.google.gson.annotations.SerializedName;
 
 import java.util.List;
 
-class Session {
+public class SessionRemote {
 
     @SerializedName("session_id")
     @Expose
@@ -19,6 +19,6 @@ class Session {
     public long date;
 
 
-    public Session(){}
+    public SessionRemote(){}
 
 }

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/Mapper.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/Mapper.java
@@ -1,0 +1,7 @@
+package br.org.cesar.discordtime.stickysessions.data.repository.mapper;
+
+public interface Mapper<A, B> {
+
+    public B mapFromDomain(A domainType);
+    public A mapToDomain(B dataType);
+}

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/NoteMapper.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/NoteMapper.java
@@ -1,0 +1,26 @@
+package br.org.cesar.discordtime.stickysessions.data.repository.mapper;
+
+import br.org.cesar.discordtime.stickysessions.data.remote.model.NoteRemote;
+import br.org.cesar.discordtime.stickysessions.domain.model.Note;
+
+public class NoteMapper implements Mapper<Note, NoteRemote> {
+    @Override
+    public NoteRemote mapFromDomain(Note domainType) {
+        NoteRemote remote = new NoteRemote();
+        remote.sessionId = domainType.sessionId;
+        remote.user = domainType.user;
+        remote.topic = domainType.topic;
+        remote.description = domainType.description;
+        return remote;
+    }
+
+    @Override
+    public Note mapToDomain(NoteRemote dataType) {
+        Note note = new Note();
+        note.sessionId = dataType.sessionId;
+        note.user = dataType.user;
+        note.topic = dataType.topic;
+        note.description = dataType.description;
+        return note;
+    }
+}

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/SessionMapper.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/SessionMapper.java
@@ -1,0 +1,22 @@
+package br.org.cesar.discordtime.stickysessions.data.repository.mapper;
+
+import br.org.cesar.discordtime.stickysessions.data.remote.model.SessionRemote;
+import br.org.cesar.discordtime.stickysessions.domain.model.Session;
+
+public class SessionMapper implements Mapper<Session, SessionRemote> {
+    @Override
+    public SessionRemote mapFromDomain(Session domainType) {
+        SessionRemote remote = new SessionRemote();
+        remote.sessionId = domainType.id;
+        remote.topics = domainType.topics;
+        return remote;
+    }
+
+    @Override
+    public Session mapToDomain(SessionRemote dataType) {
+        Session session = new Session();
+        session.id = dataType.sessionId;
+        session.topics = dataType.topics;
+        return session;
+    }
+}

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/model/Note.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/model/Note.java
@@ -5,6 +5,6 @@ public class Note {
     public String description;
     public String user;
     public String topic;
-    public String session_id;
+    public String sessionId;
 
 }

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/model/Session.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/model/Session.java
@@ -2,8 +2,8 @@ package br.org.cesar.discordtime.stickysessions.domain.model;
 
 import java.util.List;
 
-class Session {
-    public String sessionId;
+public class Session {
+    public String id;
     public List<String> topics = null;
 
 }

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/NoteMapperTest.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/NoteMapperTest.kt
@@ -1,0 +1,42 @@
+package br.org.cesar.discordtime.stickysessions.data.repository.mapper
+
+import br.org.cesar.discordtime.stickysessions.data.remote.model.NoteRemote
+import br.org.cesar.discordtime.stickysessions.domain.model.Note
+import br.org.cesar.discordtime.stickysessions.factory.NoteFactory
+import br.org.cesar.discordtime.stickysessions.factory.NoteRemoteFactory
+import org.junit.Before
+import org.junit.Test
+import org.junit.Assert.assertEquals;
+
+class NoteMapperTest {
+
+    private lateinit var noteMapper: NoteMapper
+
+    @Before
+    fun setUp() {
+        noteMapper = NoteMapper()
+    }
+
+    @Test
+    fun mapFromDomain() {
+        val note = NoteFactory.makeNote()
+        val noteRemote = noteMapper.mapFromDomain(note)
+
+        assertNoteEquality(note, noteRemote)
+    }
+
+    @Test
+    fun mapToDomain() {
+        val noteRemote = NoteRemoteFactory.makeNoteRemote()
+        val note = noteMapper.mapToDomain(noteRemote)
+
+        assertNoteEquality(note, noteRemote)
+    }
+
+    private fun assertNoteEquality(note: Note, noteRemote: NoteRemote) {
+        assertEquals(note.sessionId, noteRemote.sessionId)
+        assertEquals(note.user, noteRemote.user)
+        assertEquals(note.topic, noteRemote.topic)
+        assertEquals(note.description, noteRemote.description)
+    }
+}

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/SessionMapperTest.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/data/repository/mapper/SessionMapperTest.kt
@@ -1,0 +1,45 @@
+package br.org.cesar.discordtime.stickysessions.data.repository.mapper
+
+import br.org.cesar.discordtime.stickysessions.data.remote.model.NoteRemote
+import br.org.cesar.discordtime.stickysessions.data.remote.model.SessionRemote
+import br.org.cesar.discordtime.stickysessions.domain.model.Note
+import br.org.cesar.discordtime.stickysessions.domain.model.Session
+import br.org.cesar.discordtime.stickysessions.factory.NoteFactory
+import br.org.cesar.discordtime.stickysessions.factory.NoteRemoteFactory
+import br.org.cesar.discordtime.stickysessions.factory.SessionFactory
+import br.org.cesar.discordtime.stickysessions.factory.SessionRemoteFactory
+import org.junit.Assert.assertEquals;
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Test
+
+class SessionMapperTest {
+
+    private lateinit var sessionMapper: SessionMapper
+
+    @Before
+    fun setUp() {
+        sessionMapper = SessionMapper()
+    }
+
+    @Test
+    fun mapFromDomain() {
+        val session = SessionFactory.makeSession(5)
+        val sessionRemote = sessionMapper.mapFromDomain(session)
+
+        assertSessionEquality(session, sessionRemote)
+    }
+
+    @Test
+    fun mapToDomain() {
+        val sessionRemote = SessionRemoteFactory.makeSessionRemote(5)
+        val session = sessionMapper.mapToDomain(sessionRemote)
+
+        assertSessionEquality(session, sessionRemote)
+    }
+
+    private fun assertSessionEquality(session: Session, sessionRemote: SessionRemote) {
+        assertEquals(session.id, sessionRemote.sessionId)
+        assertTrue(session.topics.toTypedArray() contentEquals sessionRemote.topics.toTypedArray())
+    }
+}

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/DataFactory.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/DataFactory.kt
@@ -1,0 +1,22 @@
+package br.org.cesar.discordtime.stickysessions.factory
+
+import java.util.*
+
+class DataFactory {
+
+    companion object Factory {
+
+        fun randomUuid(): UUID {
+            return UUID.randomUUID()
+        }
+
+        fun randomString(): String {
+            return UUID.randomUUID().toString()
+        }
+
+        fun randomInt(): Int {
+            return Math.random().toInt()
+        }
+
+    }
+}

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/NoteFactory.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/NoteFactory.kt
@@ -1,0 +1,20 @@
+package br.org.cesar.discordtime.stickysessions.factory
+
+import br.org.cesar.discordtime.stickysessions.domain.model.Note
+import br.org.cesar.discordtime.stickysessions.factory.DataFactory.Factory.randomString
+
+class NoteFactory {
+
+    companion object Factory {
+
+        fun makeNote(): Note {
+            var note = Note()
+            note.sessionId = randomString()
+            note.user = randomString()
+            note.topic = randomString()
+            note.description = randomString()
+            return note
+        }
+
+    }
+}

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/NoteRemoteFactory.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/NoteRemoteFactory.kt
@@ -1,0 +1,20 @@
+package br.org.cesar.discordtime.stickysessions.factory
+
+import br.org.cesar.discordtime.stickysessions.data.remote.model.NoteRemote
+import br.org.cesar.discordtime.stickysessions.domain.model.Note
+
+class NoteRemoteFactory {
+
+    companion object Factory {
+
+        fun makeNoteRemote(): NoteRemote {
+            var note = NoteRemote()
+            note.sessionId = DataFactory.randomString()
+            note.user = DataFactory.randomString()
+            note.topic = DataFactory.randomString()
+            note.description = DataFactory.randomString()
+            return note
+        }
+
+    }
+}

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/SessionFactory.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/SessionFactory.kt
@@ -1,0 +1,26 @@
+package br.org.cesar.discordtime.stickysessions.factory
+
+import br.org.cesar.discordtime.stickysessions.domain.model.Session
+import br.org.cesar.discordtime.stickysessions.factory.DataFactory.Factory.randomString
+
+class SessionFactory {
+
+    companion object Factory {
+
+        private fun makeTopicsList(count: Int): List<String> {
+            val topics = mutableListOf<String>()
+            repeat(count) {
+                topics.add(randomString())
+            }
+            return topics;
+        }
+
+        fun makeSession(topicsCount: Int): Session {
+            val session = Session()
+            session.id = randomString()
+            session.topics = makeTopicsList(topicsCount)
+            return session;
+        }
+
+    }
+}

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/SessionRemoteFactory.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/factory/SessionRemoteFactory.kt
@@ -1,0 +1,25 @@
+package br.org.cesar.discordtime.stickysessions.factory
+
+import br.org.cesar.discordtime.stickysessions.data.remote.model.SessionRemote
+
+class SessionRemoteFactory {
+
+    companion object Factory {
+
+        private fun makeTopicsList(count: Int): List<String> {
+            val topics = mutableListOf<String>()
+            repeat(count) {
+                topics.add(DataFactory.randomString())
+            }
+            return topics;
+        }
+
+        fun makeSessionRemote(topicsCount: Int): SessionRemote {
+            val sessionRemote = SessionRemote()
+            sessionRemote.sessionId = DataFactory.randomString()
+            sessionRemote.topics = makeTopicsList(topicsCount)
+            return sessionRemote;
+        }
+
+    }
+}


### PR DESCRIPTION
Create Mapper interface and actual mappers for converting between
domain and remote models. Also renamed remote models with remote
suffix to better readability.

it fixes #24.