### PR TITLE
Fixes #55: Change server URL based on flavor

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # StickySessions
 
-### Config to run in Android Studio
+### Server communication
 
-- To compile in Android Studio you'll need to download the google-services.json 
-file and add it in ~/sticky-sessions-android/app.
-- To download google-service.json go to 
-[console firebase](https://console.firebase.google.com/project/sticky-sessions-bf24d/settings/general/android:br.org.cesar.discordtime.stickysessions?hl=pt-br) and click "google-services.json". 
+- Project has two flavors (`Online` and `Local`) which change backend URL used by app.
+- `Local` flavor is intended for local backend development where developer could
+  connect device via USB and use `adb reverse tcp:3000 tcp:3000` command to redirect
+  requests to local machine.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -27,6 +27,30 @@ android {
         targetCompatibility JavaVersion.VERSION_1_8
     }
 
+    flavorDimensions "server"
+
+    productFlavors {
+        online {
+            dimension "server"
+            ext {
+                url = "http://142.93.124.175"
+            }
+        }
+        local {
+            dimension "server"
+            applicationId = applicationId + ".local"
+            ext {
+                url = "http://localhost:3000"
+            }
+        }
+        applicationVariants.all { variant ->
+            def flavors = variant.productFlavors
+            // flavorDimensions "server" -> 0
+            def server = flavors[0]
+            variant.buildConfigField "String", "URL", "\"${server[url.name]}\""
+        }
+    }
+
 }
 
 dependencies {

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/components/LobbyComponent.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/components/LobbyComponent.java
@@ -3,6 +3,7 @@ package br.org.cesar.discordtime.stickysessions.injectors.components;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.ContextModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.LobbyPresenterModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.RouterModule;
+import br.org.cesar.discordtime.stickysessions.injectors.modules.ServerModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.SessionModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.ThreadModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.ViewStarterModule;
@@ -16,8 +17,8 @@ import dagger.Component;
                 ThreadModule.class,
                 ContextModule.class,
                 RouterModule.class,
-                ViewStarterModule.class
-
+                ViewStarterModule.class,
+                ServerModule.class
         }
 )
 public interface LobbyComponent {

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/components/SessionComponent.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/components/SessionComponent.java
@@ -2,6 +2,7 @@ package br.org.cesar.discordtime.stickysessions.injectors.components;
 
 import br.org.cesar.discordtime.stickysessions.injectors.modules.ContextModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.NoteModule;
+import br.org.cesar.discordtime.stickysessions.injectors.modules.ServerModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.SessionModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.SessionPresenterModule;
 import br.org.cesar.discordtime.stickysessions.injectors.modules.ThreadModule;
@@ -14,7 +15,8 @@ import dagger.Component;
         NoteModule.class,
         SessionModule.class,
         ThreadModule.class,
-        ContextModule.class
+        ContextModule.class,
+        ServerModule.class
     }
 )
 public interface SessionComponent {

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/modules/ServerModule.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/modules/ServerModule.java
@@ -1,0 +1,15 @@
+package br.org.cesar.discordtime.stickysessions.injectors.modules;
+
+import br.org.cesar.discordtime.stickysessions.BuildConfig;
+import dagger.Module;
+import dagger.Provides;
+
+@Module
+public class ServerModule {
+
+    @Provides
+    public String WebUrlProvider(){
+        return BuildConfig.URL;
+    }
+
+}

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/modules/SessionModule.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/injectors/modules/SessionModule.java
@@ -65,11 +65,6 @@ public class SessionModule {
     }
 
     @Provides
-    public String WebUrlProvider(){
-        return "http://localhost:3000";
-    }
-
-    @Provides
     public ObservableUseCase<String, Session> provideEnterSessionUseCase(
         EnterSession enterSession, ThreadExecutor threadExecutor,
         PostExecutionThread postExecutionThread) {


### PR DESCRIPTION
Added gradle configuration to change server URL based on flavor.
Now app has two flavors: Online (who points to hosted backend) and
Local (who points to localhost and requires that developer connects
device via USB and use adb reverse tcp command).

README updated accordingly.