### PR TITLE
Fix #73: Add number on gain pleasure topics text

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/interactor/CreateSession.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/interactor/CreateSession.java
@@ -21,7 +21,8 @@ public class CreateSession extends UseCase<SessionType, Session> {
         map.put(SessionType.STARFISH,
                 Arrays.asList("Less", "More", "Start", "Stop", "Keep"));
         map.put(SessionType.GAIN_PLEASURE,
-                Arrays.asList("Loss & Pain", "Loss & Pleasure", "Gain & Pain", "Gain & Pleasure"));
+                Arrays.asList("Loss & Pleasure (1)", "Gain & Pleasure (2)"
+                        , "Loss & Pain (3)", "Gain & Pain (4)"));
         mTopicsMap = Collections.unmodifiableMap(map);
     }
 

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/domain/interactor/CreateSessionTest.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/domain/interactor/CreateSessionTest.kt
@@ -24,8 +24,8 @@ class CreateSessionTest {
         mockSessionRepository = mock()
         createSession = CreateSession(mockSessionRepository)
         startfishList = Arrays.asList("Less", "More", "Start", "Stop", "Keep")
-        gainPleasureList = Arrays.asList("Loss & Pain", "Loss & Pleasure",
-                "Gain & Pain", "Gain & Pleasure")
+        gainPleasureList = Arrays.asList("Loss & Pleasure (1)", "Gain & Pleasure (2)"
+                , "Loss & Pain (3)", "Gain & Pain (4)")
     }
 
     @Test


### PR DESCRIPTION
Gain & Pleasure topics represent each a quadrant and that rule
doesn't apply for other types of sessions, so we've just added
numbers on its texts and changed their order.

![screen](https://user-images.githubusercontent.com/3610273/45214423-cf5f2300-b270-11e8-922f-729161cb1b61.png)
