### PR TITLE
Fix #80: Add CI status badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # StickySessions
 
+[![CircleCI](https://circleci.com/gh/DiscordTime/sticky-sessions-android.svg?style=svg)](https://circleci.com/gh/DiscordTime/sticky-sessions-android)
+
 ### Server communication
 
 - Project has two flavors (`Online` and `Local`) which change backend URL used by app.


### PR DESCRIPTION
Include Circle CI status badge on README as a shortcut to
last dev build and its artifacts.