### PR TITLE
Stop animating notes on session load

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/ui/adapters/NoteAdapter.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/ui/adapters/NoteAdapter.java
@@ -56,7 +56,9 @@ public class NoteAdapter extends RecyclerView.Adapter<NoteAdapter.NoteViewHolder
 
         mNotes.clear();
         mNotes.addAll(notes);
-        notifyItemRangeInserted(0, mNotes.size());
+        // TODO: fix animation crash -> IndexOutOfBoundsException: Inconsistency detected.
+        //notifyItemRangeInserted(0, mNotes.size());
+        notifyDataSetChanged();
     }
 
     public void setCallback(NoteAdapterCallback callback) {


### PR DESCRIPTION
Animating all notes on session load was crashing application with
an IndexOutOfBoundsException on RecyclerView. This change disable
animation by calling notifyDataSetChanged instead of notifyItemRange.