### PR TITLE
Lint fix for gradle version

### DIFF
--- a/app/lint.xml
+++ b/app/lint.xml
@@ -39,4 +39,8 @@
     fact it can't find androidx dependencies correclty -->
     <issue id="AppCompatResource" severity="ignore" />
 
+    <!-- Lint will just inform that there is a new version for dependencies -->
+    <issue id="NewerVersionAvailable" severity="informational" />
+    <issue id="GradleDependency" severity="informational" />
+
 </lint>


### PR DESCRIPTION
Lint will just inform that there is a new version for dependencies