### PR TITLE
Fix #133: Create another flavor for staging

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -25,7 +25,7 @@ jobs:
           key: jars-{{ checksum "build.gradle" }}-{{ checksum  "app/build.gradle" }}
       - run:
           name: Run Tests
-          command: ./gradlew lintOnlineRelease testOnlineReleaseUnitTest
+          command: ./gradlew lintProdRelease testProdReleaseUnitTest
       - store_artifacts:
           path: app/build/reports
           destination: reports
@@ -33,7 +33,7 @@ jobs:
           path: app/build/test-results
       - run:
           name: Initial build
-          command: ./gradlew clean assembleOnlineRelease --no-daemon --stacktrace
+          command: ./gradlew clean assembleProdRelease --no-daemon --stacktrace
       - store_artifacts:
           path: app/build/outputs/apk/
           destination: apks/

--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ An usual session would follow steps below:
 
 ## Server communication
 
-- Project has two flavors (`Online` and `Local`) which change backend URL used by app.
+- Project has 3 flavors (`Prod`, `Stag` and `Local`) which change backend URL used by app.
+- `Prod` is intended for production and should be used only on real meetings
+- `Stag` is intended for usual development on Android client's side
 - `Local` flavor is intended for local backend development where developer
   connects the device via USB and uses `adb reverse tcp:3000 tcp:3000` command to redirect
   requests to local machine.

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -45,11 +45,20 @@ android {
     flavorDimensions "server"
 
     productFlavors {
-        online {
+        prod {
             dimension "server"
             ext {
                 url = "http://142.93.124.175"
             }
+            resValue "string", "app_name", "Sticky Sessions"
+        }
+        stag {
+            dimension "server"
+            applicationId = "${packageId}.stag"
+            ext {
+                url = "http://142.93.124.175:8080"
+            }
+            resValue "string", "app_name", "Sticky Sessions (Staging)"
         }
         local {
             dimension "server"
@@ -57,6 +66,7 @@ android {
             ext {
                 url = "http://localhost:3000"
             }
+            resValue "string", "app_name", "Sticky Sessions (Local)"
         }
         applicationVariants.all { variant ->
             def flavors = variant.productFlavors

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,5 @@
 <resources>
-    <string name="app_name">Sticky Sessions</string>
+    <!-- app_name is defined by flavor, please see app/build.gradle -->
     <string name="confirm">Confirm</string>
     <string name="share_session">Hey fellow, you can get a new session here: http://stickysessions.com/enter?session=%s</string>
     <string name="bt_share_session">Share Session</string>


### PR DESCRIPTION
To avoid messing with production database it was created a dedicated
flavor for staging server. Also Online flavor was renamed to Prod
and Application name is defined on gradle to better identify on
device which flavor developer is currently using.