### PR TITLE
Fix #140: App allows user to add an empty note to session

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/interactor/AddNote.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/interactor/AddNote.java
@@ -18,18 +18,24 @@ public class AddNote extends UseCase<Note, Note> {
     @Override
     public Single<Note> execute(final Note note) {
         return mSessionRepository.getSession(note.sessionId).flatMap(session -> {
-            if (session != null && !session.id.isEmpty() &&
-                session.id.equals(note.sessionId) &&
-                session.topics.contains(note.topic)) {
-                return mNoteRepository.addNote(note);
-            } else {
+            if (session == null || session.id.isEmpty() || !session.id.equals(note.sessionId)) {
                 return Single.error(
-                    new IllegalArgumentException(
-                            "The note's session is invalid " +
-                            "or it doesn't contain a topic of this session."
-                    )
+                        new IllegalArgumentException("The note's session is invalid.")
                 );
             }
+            else if (!session.topics.contains(note.topic)) {
+                return Single.error(
+                        new IllegalArgumentException("The note doesn't contain a topic of this " +
+                                "session.")
+                );
+            }
+            else if (note.description == null || note.description.trim().isEmpty()) {
+                return Single.error(
+                        new IllegalArgumentException("The note can't be empty.")
+                );
+            }
+
+            return mNoteRepository.addNote(note);
         });
     }
 }

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/domain/interactor/AddNoteTest.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/domain/interactor/AddNoteTest.kt
@@ -55,6 +55,34 @@ class AddNoteTest {
         testObserver.assertError(IllegalArgumentException::class.java)
     }
 
+    @Test
+    fun `should fail if note is null`() {
+        configureSessionRepositoryMock("1", Arrays.asList("more", "less"))
+        configureRepositoryMockAddNote()
+
+        val addNote = AddNote(mNoteRepositoryMock, mSessionRepositoryMock)
+        val note = Note(null, randomString(), "more", "1")
+        val singleNote:Single<Note> = addNote.execute(note)
+
+        val testObserver:TestObserver<Note> = singleNote.test()
+        testObserver.awaitTerminalEvent()
+        testObserver.assertError(IllegalArgumentException::class.java)
+    }
+
+    @Test
+    fun `should fail if note is empty`() {
+        configureSessionRepositoryMock("1", Arrays.asList("more", "less"))
+        configureRepositoryMockAddNote()
+
+        val addNote = AddNote(mNoteRepositoryMock, mSessionRepositoryMock)
+        val note = Note("     ", randomString(), "more", "1")
+        val singleNote:Single<Note> = addNote.execute(note)
+
+        val testObserver:TestObserver<Note> = singleNote.test()
+        testObserver.awaitTerminalEvent()
+        testObserver.assertError(IllegalArgumentException::class.java)
+    }
+
     private fun configureSessionRepositoryMock(idSession:String, topics:List<String>) {
         whenever(mSessionRepositoryMock.getSession(any()))
                 .thenReturn(Single.create { emitter ->


### PR DESCRIPTION
Add validation and message feedback to prevent the user from adding
an empty note.