### PR TITLE
Fix session list order

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/repository/SessionRemoteRepository.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/repository/SessionRemoteRepository.java
@@ -48,13 +48,15 @@ public class SessionRemoteRepository implements SessionRepository {
     public Single<List<Session>> listSessions() {
         return mService.getSessions().map(sessionRemotes -> {
                 List<Session> sessions = new ArrayList<>();
+
+                // TODO: Issue #143 - Move sorting to the presentation layer
+                Collections.sort(sessionRemotes, new SessionRemoteComparator());
                 for (SessionRemote sessionRemote : sessionRemotes) {
                     Session session = mMapper.mapToDomain(sessionRemote);
                     if(session != null) {
                         sessions.add(session);
                     }
                 }
-                Collections.sort(sessionRemotes, new SessionRemoteComparator());
 
                 return sessions;
         });


### PR DESCRIPTION
Just moved sort command before mapping operation from SessionRemote
to Session objects. Also opened issue #143 to move that logic to the
presentation layer.