### PR TITLE
Fix #152: Put note's content on first plan

### DIFF
--- a/app/src/main/res/layout/activity_session.xml
+++ b/app/src/main/res/layout/activity_session.xml
@@ -49,6 +49,7 @@
         android:id="@+id/user_notes_recyclerview"
         android:layout_width="match_parent"
         android:layout_height="0dp"
+        android:layout_marginTop="8dp"
         android:paddingTop="8dp"
         android:layout_marginStart="8dp"
         android:layout_marginEnd="8dp"

--- a/app/src/main/res/layout/note_element.xml
+++ b/app/src/main/res/layout/note_element.xml
@@ -22,12 +22,11 @@
 
     <TextView
         android:id="@+id/title_note_element"
-        android:layout_width="match_parent"
+        android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         style="@style/NoteStyleTitlePreview"
         app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toBottomOf="parent"
         tools:text="Note Title"
         android:textIsSelectable="false"/>
 
@@ -36,12 +35,11 @@
         android:layout_width="0dp"
         android:layout_height="0dp"
         style="@style/NoteStyleContentPreview"
-        app:layout_constraintLeft_toLeftOf="@+id/title_note_element"
-        app:layout_constraintRight_toRightOf="@+id/title_note_element"
-        app:layout_constraintTop_toBottomOf="@+id/title_note_element"
-        app:layout_constraintBottom_toBottomOf="parent"
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintBottom_toTopOf="@+id/title_note_element"
         tools:text="This is a great text to check if the textview will break the textview"
         android:textIsSelectable="false"/>
-
 
 </br.org.cesar.discordtime.stickysessions.ui.session.custom.SquaredConstraintLayout>

--- a/app/src/main/res/layout/note_element_dialog.xml
+++ b/app/src/main/res/layout/note_element_dialog.xml
@@ -14,18 +14,18 @@
         android:layout_width="0dp"
         android:layout_height="wrap_content"
         style="@style/NoteStyleTitle"
-        app:layout_constraintLeft_toLeftOf="parent"
-        app:layout_constraintRight_toRightOf="parent"
-        app:layout_constraintTop_toTopOf="parent"
+        app:layout_constraintLeft_toLeftOf="@+id/scrollview_note_element"
+        app:layout_constraintTop_toBottomOf="@+id/scrollview_note_element"
         tools:text="Note Title"
         android:textIsSelectable="true"/>
 
     <ScrollView
+        android:id="@+id/scrollview_note_element"
         android:layout_width="match_parent"
         android:layout_height="250dp"
-        app:layout_constraintLeft_toLeftOf="@+id/title_note_element"
-        app:layout_constraintRight_toRightOf="@+id/title_note_element"
-        app:layout_constraintTop_toBottomOf="@+id/title_note_element">
+        app:layout_constraintLeft_toLeftOf="parent"
+        app:layout_constraintRight_toRightOf="parent"
+        app:layout_constraintTop_toTopOf="parent">
 
         <TextView
             android:id="@+id/description_note_element"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -33,19 +33,24 @@
         <item name="android:paddingRight">5dp</item>
     </style>
 
-    <style name="NoteStyleTitle" parent="NoteStyle">
-        <item name="android:textSize">48sp</item>
+    <style name="NoteStyleForTopic" parent="NoteStyle">
+        <item name="android:textColor">@color/colorPrimary</item>
+        <item name="android:textStyle">bold</item>
+    </style>
+
+    <style name="NoteStyleTitle" parent="NoteStyleForTopic">
+        <item name="android:textSize">20sp</item>
         <item name="android:gravity">left</item>
     </style>
 
-    <style name="NoteStyleTitlePreview" parent="NoteStyle">
-        <item name="android:textSize">24sp</item>
+    <style name="NoteStyleTitlePreview" parent="NoteStyleForTopic">
+        <item name="android:textSize">16sp</item>
         <item name="android:gravity">center</item>
         <item name="android:textAlignment">viewStart</item>
     </style>
 
     <style name="NoteStyleContent" parent="NoteStyle">
-        <item name="android:textSize">36sp</item>
+        <item name="android:textSize">34sp</item>
         <item name="android:gravity">center_horizontal</item>
         <item name="android:paddingLeft">20dp</item>
         <item name="android:paddingRight">20dp</item>
@@ -53,7 +58,7 @@
     </style>
 
     <style name="NoteStyleContentPreview" parent="NoteStyleContent">
-        <item name="android:textSize">18sp</item>
+        <item name="android:textSize">20sp</item>
         <item name="android:ellipsize">end</item>
         <item name="android:singleLine">false</item>
     </style>


### PR DESCRIPTION
Changed note's topic position, size and color to put note's content on first plan. Also moved first note row a bit down to avoid new note button.  