### PR TITLE
Fix #154: Crash while fast clicking on session item

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsContract.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsContract.java
@@ -13,7 +13,7 @@ public interface ListSessionsContract {
         void attachView(ListSessionsContract.View view);
         void detachView();
         void onLoad();
-        void onPause();
+        void onStop();
         void enterOnSession(Session session);
         void onSwipeLeft(Session session);
         void onDateSelected(int year, int month, int day);

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsPresenter.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsPresenter.java
@@ -58,7 +58,7 @@ public class ListSessionsPresenter implements ListSessionsContract.Presenter {
     }
 
     @Override
-    public void onPause() {
+    public void onStop() {
         mLogger.d(TAG, "onPause List Session view.");
         disposeObservers();
     }
@@ -122,7 +122,7 @@ public class ListSessionsPresenter implements ListSessionsContract.Presenter {
     @Override
     public void enterOnSession(Session session) {
         if (session != null) {
-            mLogger.d(TAG, "enterOnSession : "+session.id);
+            mLogger.d(TAG, "enterOnSession : " + session.id);
             IBundle bundle = mBundleFactory.create();
             goNext(session, bundle);
         } else {
@@ -152,14 +152,16 @@ public class ListSessionsPresenter implements ListSessionsContract.Presenter {
     }
 
     private void goNext(Session session, IBundle bundle) {
-        bundle.putString(ExtraNames.SESSION_ID, session.id);
+        if (mView != null) {
+            bundle.putString(ExtraNames.SESSION_ID, session.id);
 
-        try {
-            Route route = mRouter.getNext(mView.getName(), IRouter.USER_SELECTED_SESSION);
-            mView.goNext(route, bundle);
-        } catch (InvalidRouteException | InvalidViewNameException e) {
-            mLogger.e(TAG, e.getMessage());
-            e.printStackTrace();
+            try {
+                Route route = mRouter.getNext(mView.getName(), IRouter.USER_SELECTED_SESSION);
+                mView.goNext(route, bundle);
+            } catch (InvalidRouteException | InvalidViewNameException e) {
+                mLogger.e(TAG, e.getMessage());
+                e.printStackTrace();
+            }
         }
     }
 }

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/ui/list/ListSessionsActivity.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/ui/list/ListSessionsActivity.java
@@ -111,16 +111,16 @@ public class ListSessionsActivity extends AppCompatActivity
     }
 
     @Override
-    protected void onResume() {
-        super.onResume();
+    protected void onStart() {
+        super.onStart();
         mPresenter.attachView(this);
         mPresenter.onLoad();
     }
 
     @Override
-    protected void onPause() {
-        super.onPause();
-        mPresenter.onPause();
+    protected void onStop() {
+        super.onStop();
+        mPresenter.onStop();
     }
 
     @Override

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsPresenterTest.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsPresenterTest.kt
@@ -66,7 +66,7 @@ class ListSessionsPresenterTest {
 
         listSessionsPresenter.onLoad()
         verify(mockLisSessions).execute(captor.capture(), isNull())
-        listSessionsPresenter.onPause()
+        listSessionsPresenter.onStop()
         assertTrue(captor.firstValue.isDisposed)
     }
 


### PR DESCRIPTION
The presenter was detaching the view on the onPause method that was being called on the onPause android lifecycle method therefore when the user presses another time the mView property was not present resulting in a NullPointerException. I changed the lifecycle events from onPause to onStop and onResume to onStart.