### PR TITLE
Fix the screen orientation for portrait

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,9 @@ android {
         versionCode versionMap.code
         versionName versionMap.name
         testInstrumentationRunner "br.org.cesar.discordtime.stickysessions.MockTestRunner"
+        manifestPlaceholders = [
+            orientation: "portrait"
+        ]
     }
 
     buildTypes {

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -5,6 +5,9 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
 
+    <!-- The app requires this feature because all the activities are fixed portrait orientation -->
+    <uses-feature android:name="android.hardware.screen.portrait" />
+
     <application
         android:name=".app.StickySessionApplication"
         android:allowBackup="false"
@@ -15,7 +18,7 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
         <activity android:name=".ui.login.LoginActivity"
-            android:screenOrientation="portrait"
+            android:screenOrientation="${orientation}"
             android:theme="@style/LaunchTheme">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
@@ -25,7 +28,7 @@
         </activity>
         <activity
             android:name=".ui.lobby.LobbyActivity"
-            android:screenOrientation="portrait">
+            android:screenOrientation="${orientation}">
             <intent-filter android:label="@string/app_name">
                 <action android:name="android.intent.action.VIEW" />
 
@@ -34,6 +37,7 @@
         </activity>
         <activity
             android:name=".ui.session.SessionActivity"
+            android:screenOrientation="${orientation}"
             android:launchMode="singleTop"
             android:theme="@style/LaunchTheme">
             <intent-filter android:label="@string/app_name">
@@ -50,6 +54,7 @@
         </activity>
         <activity
             android:name=".ui.list.ListSessionsActivity"
+            android:screenOrientation="${orientation}"
             android:parentActivityName=".ui.lobby.LobbyActivity" />
 
         <meta-data


### PR DESCRIPTION
There are activities that are not set as portrait and
the app layout does not work in landscape and the app
screens must be fixed in portrait.

For that, add screen orientation for all the app activities
and add user-feature "android.hardware.screen.portrait" for
info that the app work in portrait only.

fixed: #176