### PR TITLE
Fix ListSession instrumented test to consider meeting id

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -164,7 +164,8 @@ workflows:
             - build
           filters:
             branches:
-              only: dev
+              only:
+                - dev
       - deploy_to_crashlytics:
           requires:
             - test_instrumented

--- a/app/src/androidTest/java/br/org/cesar/discordtime/stickysessions/ui/list/ListSessionsActivityEspressoTest.kt
+++ b/app/src/androidTest/java/br/org/cesar/discordtime/stickysessions/ui/list/ListSessionsActivityEspressoTest.kt
@@ -10,6 +10,7 @@ import androidx.test.rule.ActivityTestRule
 import androidx.test.runner.AndroidJUnit4
 import br.org.cesar.discordtime.stickysessions.MockServerDispatcher
 import br.org.cesar.discordtime.stickysessions.R
+import br.org.cesar.discordtime.stickysessions.ui.ExtraNames
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.After
 import org.junit.Before
@@ -42,7 +43,11 @@ class ListSessionsActivityEspressoTest {
     fun activityIsUpAndRunning() {
 
         webServer.setDispatcher(MockServerDispatcher().RequestDispatcher())
-        activityRule.launchActivity(Intent())
+
+        val intent = Intent()
+        intent.putExtra(ExtraNames.MEETING_ID, "20.12.2018")
+
+        activityRule.launchActivity(intent)
 
         onView(withId(R.id.session_list))
                 .check(matches(isDisplayed()))

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsPresenter.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/list/ListSessionsPresenter.java
@@ -72,7 +72,7 @@ public class ListSessionsPresenter implements ListSessionsContract.Presenter {
 
     private void disposeObservers() {
         mView = null;
-        mListSessionsObserver.dispose();
+        if (mListSessionsObserver != null) mListSessionsObserver.dispose();
     }
 
     private void initObservers() {


### PR DESCRIPTION
ListSession's instrumented test was failing because current
implementation expects to receive a meeting id via Intent.