### PR TITLE
Remove user from list notes endpoint request

### DIFF
--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/NoteRemote.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/NoteRemote.java
@@ -12,7 +12,7 @@ public class NoteRemote {
     @Expose
     public String description;
     @SerializedName("user")
-    @Expose
+    @Expose(serialize = false)
     public String user;
     @SerializedName("topic")
     @Expose

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/SessionRemote.kt
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/SessionRemote.kt
@@ -1,11 +1,12 @@
 package br.org.cesar.discordtime.stickysessions.data.remote.model
 
+import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
 data class SessionRemote(
-        @SerializedName("id") var id: String,
-        @SerializedName("topics") var topics: List<String>,
-        @SerializedName("timestamp") var timestamp: Long
+        @Expose @SerializedName("id") var id: String,
+        @Expose @SerializedName("topics") var topics: List<String>,
+        @Expose @SerializedName("timestamp") var timestamp: Long
 ) {
     constructor(id: String, topics: List<String>) : this(id,topics,0)
 

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/SessionRemoteFirebase.kt
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/model/SessionRemoteFirebase.kt
@@ -1,15 +1,16 @@
 package br.org.cesar.discordtime.stickysessions.data.remote.model
 
+import com.google.gson.annotations.Expose
 import com.google.gson.annotations.SerializedName
 
 data class SessionRemoteFirebase(
-        @SerializedName("id") var id: String,
-        @SerializedName("topics") var topics: List<String>,
-        @SerializedName("timestamp") var timestamp: TimeStampRemote?
+        @Expose @SerializedName("id") var id: String,
+        @Expose @SerializedName("topics") var topics: List<String>,
+        @Expose @SerializedName("timestamp") var timestamp: TimeStampRemote?
 ) {
     constructor(id: String, topics: List<String>) : this(id,topics,TimeStampRemote(0))
 }
 
 data class TimeStampRemote(
-        @SerializedName("_seconds") var seconds: Long
+        @Expose @SerializedName("_seconds") var seconds: Long
 )

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/repository/NoteRemoteRepository.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/repository/NoteRemoteRepository.java
@@ -32,7 +32,7 @@ public class NoteRemoteRepository implements NoteRepository {
 
     @Override
     public Single<List<Note>> listNotesForSession(NoteFilter noteFilter) {
-        return mNoteService.listNotesForSession(noteFilter.idSession, noteFilter.user).map(
+        return mNoteService.listNotesForSession(noteFilter.idSession).map(
             noteRemotes -> {
                 List<Note> mNotes = new ArrayList<>();
 

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/service/NoteService.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/service/NoteService.java
@@ -10,13 +10,14 @@ import retrofit2.http.DELETE;
 import retrofit2.http.GET;
 import retrofit2.http.POST;
 import retrofit2.http.Path;
+import retrofit2.http.Query;
 
 public interface NoteService {
     @POST("/notes")
     Single<NoteRemote> addNote(@Body NoteRemote note);
 
-    @GET("/notes/{id}/{user}")
-    Single<List<NoteRemote>> listNotesForSession(@Path("id") String id, @Path("user") String user);
+    @GET("/notes")
+    Single<List<NoteRemote>> listNotesForSession(@Query("session_id") String sessionId);
 
     @DELETE("/notes/{id}")
     Single<ResponseBody> removeNote(@Path("id") String id);

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/service/RemoteServiceFactory.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/data/remote/service/RemoteServiceFactory.java
@@ -1,5 +1,8 @@
 package br.org.cesar.discordtime.stickysessions.data.remote.service;
 
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+
 import okhttp3.OkHttpClient;
 import retrofit2.Retrofit;
 import retrofit2.adapter.rxjava2.RxJava2CallAdapterFactory;
@@ -11,11 +14,15 @@ public class RemoteServiceFactory<T> {
                                OkHttpClient okHttpClient) {
         Retrofit retrofit = new Retrofit.Builder()
                 .baseUrl(baseUrl)
-                .addConverterFactory(GsonConverterFactory.create())
+                .addConverterFactory(GsonConverterFactory.create(getGson()))
                 .addCallAdapterFactory(RxJava2CallAdapterFactory.create())
                 .client(okHttpClient)
                 .build();
         return retrofit.create(serviceClass);
+    }
+
+    private Gson getGson() {
+        return new GsonBuilder().excludeFieldsWithoutExposeAnnotation().create();
     }
 
 }

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/model/NoteFilter.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/domain/model/NoteFilter.java
@@ -2,11 +2,9 @@ package br.org.cesar.discordtime.stickysessions.domain.model;
 
 public class NoteFilter {
 
-    public String user;
     public String idSession;
 
-    public NoteFilter(String idSession, String user) {
-        this.user = user;
+    public NoteFilter(String idSession) {
         this.idSession = idSession;
     }
 }

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/session/SessionPresenter.java
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/presentation/session/SessionPresenter.java
@@ -128,7 +128,7 @@ public class SessionPresenter implements SessionContract.Presenter {
                     mView.stopLoadingAllNotes();
                     mView.displayErrorInvalidNotes();
                 }
-            }, new NoteFilter(mActiveSession.id, mCurrentUser));
+            }, new NoteFilter(mActiveSession.id));
         } else {
             mView.stopLoadingAllNotes();
             mView.displayErrorInvalidNotes();

--- a/app/src/main/java/br/org/cesar/discordtime/stickysessions/ui/meeting/MeetingActivity.kt
+++ b/app/src/main/java/br/org/cesar/discordtime/stickysessions/ui/meeting/MeetingActivity.kt
@@ -2,6 +2,7 @@ package br.org.cesar.discordtime.stickysessions.ui.meeting
 
 import android.annotation.SuppressLint
 import android.os.Bundle
+import android.util.Log
 import android.view.View
 import android.widget.ProgressBar
 import android.widget.TextView
@@ -17,6 +18,7 @@ import br.org.cesar.discordtime.stickysessions.navigation.wrapper.IViewStarter
 import br.org.cesar.discordtime.stickysessions.presentation.meeting.MeetingContract
 import br.org.cesar.discordtime.stickysessions.presentation.meeting.MeetingItem
 import br.org.cesar.discordtime.stickysessions.ui.ViewNames
+import kotlinx.android.synthetic.main.activity_meeting.*
 import javax.inject.Inject
 import kotlinx.android.synthetic.main.activity_meeting.recycler_view_meetings as mRecyclerView
 
@@ -85,7 +87,7 @@ class MeetingActivity : AppCompatActivity(), MeetingContract.View {
     }
 
     override fun showError(message: String) {
-        TODO("not implemented")
+        Log.e(TAG, message)
     }
 
     override fun showMeetings(meetings: MutableList<MeetingItem>) {
@@ -99,5 +101,9 @@ class MeetingActivity : AppCompatActivity(), MeetingContract.View {
     @Throws(InvalidViewNameException::class)
     override fun goNext(route: Route, bundle: IBundle) {
         mViewStarter.goNext(this, route.to, route.shouldClearStack, bundle)
+    }
+
+    companion object {
+        const val TAG = "MeetingActivity"
     }
 }

--- a/app/src/test/java/br/org/cesar/discordtime/stickysessions/domain/interactor/ListNotesForSessionTest.kt
+++ b/app/src/test/java/br/org/cesar/discordtime/stickysessions/domain/interactor/ListNotesForSessionTest.kt
@@ -1,6 +1,5 @@
 package br.org.cesar.discordtime.stickysessions.domain.interactor
 
-import android.provider.ContactsContract
 import br.org.cesar.discordtime.stickysessions.domain.model.Note
 import br.org.cesar.discordtime.stickysessions.domain.model.NoteFilter
 import br.org.cesar.discordtime.stickysessions.domain.model.Session
@@ -31,7 +30,6 @@ class ListNotesForSessionTest {
     @Test
     fun `invalid session id should throw an exception`(){
         val sessionId = "invalid_session_id"
-        val user = "any_user"
 
         whenever(mSessionRepositoryMock.getSession(sessionId))
                 .thenReturn(Single.create { emitter ->
@@ -39,7 +37,7 @@ class ListNotesForSessionTest {
                 })
 
         val listNotes = ListNotesForSession(mNoteRepositoryMock, mSessionRepositoryMock)
-        val singleListNote: Single<List<Note>> = listNotes.execute(NoteFilter(sessionId, user))
+        val singleListNote: Single<List<Note>> = listNotes.execute(NoteFilter(sessionId))
 
         val testObserver: TestObserver<List<Note>> = singleListNote.test()
         testObserver.awaitTerminalEvent()
@@ -49,7 +47,6 @@ class ListNotesForSessionTest {
     @Test
     fun `valid session id should return value`() {
         val sessionId = "session"
-        val user = "valid_user"
 
         whenever(mSessionRepositoryMock.getSession(sessionId))
                 .thenReturn(Single.create { emitter ->
@@ -69,7 +66,7 @@ class ListNotesForSessionTest {
                 })
 
         val listNotes = ListNotesForSession(mNoteRepositoryMock, mSessionRepositoryMock)
-        val singleListNote: Single <List<Note>> = listNotes.execute(NoteFilter(sessionId, user))
+        val singleListNote: Single <List<Note>> = listNotes.execute(NoteFilter(sessionId))
 
         val testObserver: TestObserver<List<Note>> = singleListNote.test()
         testObserver.awaitTerminalEvent()


### PR DESCRIPTION
List notes endpoint doesn't accept user as parameter anymore, so
clients shouldn't included it on requests. However, notes response
includes user on model, so we had to change how GSON serialize and
deserialize objects.